### PR TITLE
Rename about.md to syllabus.md, update repository documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+TODO write docs for staff here
+
+## Continuous Integration (GitHub Actions)
+
+TODO Info here about workflows and links
+
+## Testing
+
+To run tests, run `bundle exec rspec`
+
+## Resources
+
+- [Jekyll](https://jekyllrb.com/)
+- [GitHub](https://docs.github.com/)

--- a/README.md
+++ b/README.md
@@ -1,39 +1,41 @@
----
-layout: home
-title: Just the Class
-nav_exclude: true
-permalink: /:path/
-seo:
-  type: Course
-  name: Just the Class
----
+# Berkeley Class Site
 
-# Just the Class
+A template for UC Berkeley class websites (with a focus on EECS/CS/DS courses).
 
-Just the Class is a GitHub Pages template developed for the purpose of quickly deploying course websites. In addition to serving plain web pages and files, it provides a boilerplate for:
+## Installation
 
-- [announcements](announcements.md),
-- a [course calendar](calendar.md),
-- a [staff](staff.md) page,
-- and a weekly [schedule](schedule.md).
+Prerequisites:
 
-Just the Class is a template that extends the popular [Just the Docs](https://github.com/just-the-docs/just-the-docs) theme, which provides a robust and thoroughly-tested foundation for your website. Just the Docs include features such as:
+- You have everything that [Jekyll requires](https://jekyllrb.com/docs/installation/)
+- You have installed [Bundler](https://bundler.io/): Run `gem install jekyll bundler`
 
-- automatic [navigation structure](https://just-the-docs.github.io/just-the-docs/docs/navigation-structure/),
-- instant, full-text [search](https://just-the-docs.github.io/just-the-docs/docs/search/) and page indexing,
-- and a set of [UI components](https://just-the-docs.github.io/just-the-docs/docs/ui-components) and authoring [utilities](https://just-the-docs.github.io/just-the-docs/docs/utilities).
+1. [Fork](https://github.com/berkeley-eecs/berkeley-class-site/fork) the repository.
+2. Clone your fork (replace `YOUR_GITHUB_USERNAME` and `YOUR_REPO` accordingly).
+```
+git clone git@github.com:YOUR_GITHUB_USERNAME/YOUR_REPO.git
+```
+3. Install dependencies:
+```
+cd YOUR_REPO
+bundle install
+```
 
-## Getting Started
+## Usage
 
-Getting started with Just the Class is simple.
+To run the site locally, run:
 
-1. Create a [new repository based on Just the Class](https://github.com/kevinlin1/just-the-class/generate).
-1. Update `_config.yml` and `README.md` with your course information. [Be sure to update the url and baseurl](https://mademistakes.com/mastering-jekyll/site-url-baseurl/).
-1. Configure a [publishing source for GitHub Pages](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages). Your course website is now live!
-1. Edit and create `.md` [Markdown files](https://guides.github.com/features/mastering-markdown/) to add more content pages.
+```
+bundle exec jekyll serve
+```
 
-Just the Class has been used by instructors at Stanford University ([CS 161](https://stanford-cs161.github.io/winter2021/)), UC Berkeley ([Data 100](https://ds100.org/fa21/)), UC Santa Barbara ([CSW8](https://ucsb-csw8.github.io/s22/)), Northeastern University ([CS4530/5500](https://neu-se.github.io/CS4530-CS5500-Spring-2021/)), and Carnegie Mellon University ([17-450/17-950](https://cmu-crafting-software.github.io/)). Share your course website and find more examples in the [show and tell discussion](https://github.com/kevinlin1/just-the-class/discussions/categories/show-and-tell)!
+## Deployment
 
-### Local development environment
+The easiest way to deploy your site is with [GitHub Pages](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/about-github-pages-and-jekyll).
 
-Just the Class requires no special Jekyll plugins and can run on GitHub Pages' standard Jekyll compiler. To setup a local development environment, clone your template repository and follow the GitHub Docs on [Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).
+## Contributing
+
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for instructions on how to develop this site as part of course staff or if you're interested in contributing to this template repository.
+
+## License
+
+[MIT](LICENSE)

--- a/home.md
+++ b/home.md
@@ -1,0 +1,39 @@
+---
+layout: home
+title: Just the Class
+nav_exclude: true
+permalink: /:path/
+seo:
+  type: Course
+  name: Just the Class
+---
+
+# Just the Class
+
+Just the Class is a GitHub Pages template developed for the purpose of quickly deploying course websites. In addition to serving plain web pages and files, it provides a boilerplate for:
+
+- [announcements](announcements.md),
+- a [course calendar](calendar.md),
+- a [staff](staff.md) page,
+- and a weekly [schedule](schedule.md).
+
+Just the Class is a template that extends the popular [Just the Docs](https://github.com/just-the-docs/just-the-docs) theme, which provides a robust and thoroughly-tested foundation for your website. Just the Docs include features such as:
+
+- automatic [navigation structure](https://just-the-docs.github.io/just-the-docs/docs/navigation-structure/),
+- instant, full-text [search](https://just-the-docs.github.io/just-the-docs/docs/search/) and page indexing,
+- and a set of [UI components](https://just-the-docs.github.io/just-the-docs/docs/ui-components) and authoring [utilities](https://just-the-docs.github.io/just-the-docs/docs/utilities).
+
+## Getting Started
+
+Getting started with Just the Class is simple.
+
+1. Create a [new repository based on Just the Class](https://github.com/kevinlin1/just-the-class/generate).
+1. Update `_config.yml` and `README.md` with your course information. [Be sure to update the url and baseurl](https://mademistakes.com/mastering-jekyll/site-url-baseurl/).
+1. Configure a [publishing source for GitHub Pages](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages). Your course website is now live!
+1. Edit and create `.md` [Markdown files](https://guides.github.com/features/mastering-markdown/) to add more content pages.
+
+Just the Class has been used by instructors at Stanford University ([CS 161](https://stanford-cs161.github.io/winter2021/)), UC Berkeley ([Data 100](https://ds100.org/fa21/)), UC Santa Barbara ([CSW8](https://ucsb-csw8.github.io/s22/)), Northeastern University ([CS4530/5500](https://neu-se.github.io/CS4530-CS5500-Spring-2021/)), and Carnegie Mellon University ([17-450/17-950](https://cmu-crafting-software.github.io/)). Share your course website and find more examples in the [show and tell discussion](https://github.com/kevinlin1/just-the-class/discussions/categories/show-and-tell)!
+
+### Local development environment
+
+Just the Class requires no special Jekyll plugins and can run on GitHub Pages' standard Jekyll compiler. To setup a local development environment, clone your template repository and follow the GitHub Docs on [Testing your GitHub Pages site locally with Jekyll](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll).

--- a/syllabus.md
+++ b/syllabus.md
@@ -1,11 +1,11 @@
 ---
 layout: page
-title: About
+title: Syllabus
 description: >-
     Course policies and information.
 ---
 
-# About
+# Syllabus
 {:.no_toc}
 
 ## Table of contents


### PR DESCRIPTION
- Rename about.md to syllabus.md
- Rename old README.md to home.md since it's used as a home page of the website
- Add actual repository README.md
- Add CONTRIBUTING.md (WIP)